### PR TITLE
add another example to visualize viridis palette

### DIFF
--- a/R/viridis.R
+++ b/R/viridis.R
@@ -45,7 +45,14 @@
 #' ggplot(dat, aes(x = x, y = y)) +
 #'   geom_hex() + coord_fixed() +
 #'   scale_fill_gradientn(colours = viridis(256))
-#'
+#' 
+#' # using code from RColorBrewer to demo the palette
+#' n = 200
+#' image(
+#'   1:n,1,as.matrix(1:n)
+#'   ,col=viridis(n)
+#'   ,xlab="viridis n",ylab="",xaxt="n",yaxt="n",bty="n"
+#' )
 #' @export
 #'
 viridis <- function(n, alpha = 1) {


### PR DESCRIPTION
add example for roxygen using code from ` RColorBrewer::display.brewer.pal` to show the `viridis` palette.  I did not rerun roxygen.