### PR TITLE
Add Dockerfile for building/testing

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,4 @@
 img
 data-raw
 cran_graphs.R
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM rocker/r-devel
+MAINTAINER Noam Ross noam.ross@gmail.com
+
+RUN rm -rf /var/lib/apt/lists/ \
+  && apt-get update \
+  && apt-get install -y -t unstable --no-install-recommends \
+    libcurl4-openssl-dev \
+    libssl1.0.0 \
+    libssl-dev \
+    libproj-dev \
+    libgdal-dev \
+    libgdal1-dev \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/
+
+RUN wget https://github.com/jgm/pandoc/releases/download/1.16.0.2/pandoc-1.16.0.2-1-amd64.deb && \
+    dpkg -i pandoc* && \
+    rm pandoc* && \
+    apt-get clean
+
+RUN install2.r -r http://cran.rstudio.com \
+    openssl \
+    httr \
+    rgdal \
+    ggplot2 \
+    gridExtra \
+    hexbin \
+    scales \
+    MASS \
+    knitr \
+    dichromat \
+    colorspace \
+    rasterVis \
+    mapproj \
+    rmarkdown


### PR DESCRIPTION
The added Dockerfile contains everything needed
to build and test on the R-development branch,
based on the rocker/r-devel image but including
spatial libraries and needed packages.