### PR TITLE
Move viridisLite to “Imports”

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,12 +19,12 @@ License: MIT + file LICENSE
 LazyData: TRUE
 Encoding: UTF-8
 Depends:
-    R (>= 2.10),
-    viridisLite (>= 0.2.0)
+    R (>= 2.10)
 Imports:
     stats,
     ggplot2 (>= 1.0.1),
-    gridExtra
+    gridExtra,
+    viridisLite (>= 0.2.0)
 Suggests:
     hexbin (>= 1.27.0),
     scales,


### PR DESCRIPTION
Since everything is imported and exported anyway, this only changes that `viridisLite` is no longer attached to the `search()` path, all symbols remain accessible by users who called `library(viridis)`

Fixes #46.